### PR TITLE
Remove outdated documentation / build instructions for Cygwin build

### DIFF
--- a/Compiling-on-Cygwin.md
+++ b/Compiling-on-Cygwin.md
@@ -49,10 +49,6 @@ Note: installing the above also causes the following to be installed:
 <pre><code>$ cd /usr/src
 $ git clone https://github.com/OpenSC/OpenSC.git
 $ cd OpenSC</code></pre>
-2. Check the version of configure.ac does not define CRYPTOKI_FORCE_WIN32.
-
-   So, edit configure.ac and comment out (#) line at (approx) 107, that looks like: 
-      <pre><code>  CPPFLAGS="$... -DCRYPTOKI_FORCE_WIN32"</code></pre>
 3. Then perform commands:
 <pre><code>$ ./bootstrap
 $ ./configure --disable-strict

--- a/Compiling-on-Cygwin.md
+++ b/Compiling-on-Cygwin.md
@@ -49,7 +49,7 @@ Note: installing the above also causes the following to be installed:
 <pre><code>$ cd /usr/src
 $ git clone https://github.com/OpenSC/OpenSC.git
 $ cd OpenSC</code></pre>
-3. Then perform commands:
+2. Then perform commands:
 <pre><code>$ ./bootstrap
 $ ./configure
 $ make

--- a/Compiling-on-Cygwin.md
+++ b/Compiling-on-Cygwin.md
@@ -51,7 +51,7 @@ $ git clone https://github.com/OpenSC/OpenSC.git
 $ cd OpenSC</code></pre>
 3. Then perform commands:
 <pre><code>$ ./bootstrap
-$ ./configure --disable-strict
+$ ./configure
 $ make
 $ make install</code></pre>
 


### PR DESCRIPTION
Update documentation to current Cygwin compiling specs.

closes #7