### PR TITLE
0.25.0-rc1: add Nitrokey Start and Pro 2 test results

### DIFF
--- a/Smart-Card-Release-Testing.md
+++ b/Smart-Card-Release-Testing.md
@@ -108,7 +108,7 @@ The table below shows a list of all tested smart cards that were used:
 | cardos            | CardOS 5.3 (2023, 4k RSA, 2k RSA)                                |
 | cac               | CAC test cards, virt_CACard                                      |
 | cac1              | CAC test cards                                                   |
-| openpgp           | OpenPGP Applet  (JCardSim), NitroKey Start                       |
+| openpgp           | OpenPGP Applet (JCardSim), Nitrokey Start (RTM.10), Nitrokey Pro 2 (0.14)|
 | isoApplet         | IsoApplet v0 and v1 (JCardSim)                                   |
 | epass2003         | ePass2003 PKI Token (2023)                                       |
 | gids              | GIDS Applet  (JCardSim)                                          |


### PR DESCRIPTION
As discussed in https://github.com/OpenSC/OpenSC/issues/3017, here are the basic testing results (`pkcs11-tool --login --test`) for Nitrokey Start and Pro 2 (full output below for completeness).

Start seems to have a problem at the very last step (thus "many tests passed" and not "all"), but this was present before the changes for 0.25.0-rc1 went in (`master` as of at least a month or so ago). I plan to look into this later, after I update the token to the latest FW (RTM.13), which I'm having some troubles with at the moment.

```console
# Nitrokey Start
[user@host dir]$ ./install/bin/pkcs11-tool --module=./install/lib/opensc-pkcs11.so --test --login --pin <removed>
Using slot 0 with a present token (0x0)
C_SeedRandom() and C_GenerateRandom():
  seeding (C_SeedRandom) not supported
  seems to be OK
Digests:
  all 4 digest functions seem to work
  MD5: OK
  RIPEMD160: OK
  SHA-1: OK
  SHA256: OK
Ciphers: not implemented
Signatures (currently only for RSA)
  testing key 0 (Encryption key)  -- can't be used for signature, skipping
  testing key 1 (Authentication key) 
  all 4 signature functions seem to work
  testing signature mechanisms:
    RSA-PKCS: OK
    SHA1-RSA-PKCS: OK
    MD5-RSA-PKCS: OK
    RIPEMD160-RSA-PKCS: OK
    SHA256-RSA-PKCS: OK
  testing key 1 (Authentication key) with 1 mechanism
    RSA-PKCS: OK
Verify (currently only for RSA)
  testing key 0 (Encryption key) -- can't be used to sign/verify, skipping
  testing key 1 (Authentication key) with 1 mechanism
    RSA-PKCS: OK
Unwrap: not implemented
Decryption (currently only for RSA)
  testing key 0 (Encryption key)
    RSA-PKCS: OK
  testing key 1 (Authentication key)
error: PKCS11 function C_Decrypt failed: rv = CKR_GENERAL_ERROR (0x5)
Aborting.
    RSA-PKCS: [user@host dir]$ 

# Nitrokey Pro 2
[user@host dir]$ ./install/bin/pkcs11-tool --module=./install/lib/opensc-pkcs11.so --test --login --pin <removed>
C_SeedRandom() and C_GenerateRandom():
  seeding (C_SeedRandom) not supported
  seems to be OK
Digests:
  all 4 digest functions seem to work
  MD5: OK
  RIPEMD160: OK
  SHA-1: OK
  SHA256: OK
Ciphers: not implemented
Signatures (currently only for RSA)
  testing key 0 (Encryption key)  -- can't be used for signature, skipping
  testing key 1 (Authentication key) 
  all 4 signature functions seem to work
  testing signature mechanisms:
    RSA-PKCS: OK
    SHA1-RSA-PKCS: OK
    MD5-RSA-PKCS: OK
    RIPEMD160-RSA-PKCS: OK
    SHA256-RSA-PKCS: OK
  testing key 1 (Authentication key) with 1 mechanism
    RSA-PKCS: OK
Verify (currently only for RSA)
  testing key 0 (Encryption key) -- can't be used to sign/verify, skipping
  testing key 1 (Authentication key) with 1 mechanism
    RSA-PKCS: OK
Unwrap: not implemented
Decryption (currently only for RSA)
  testing key 0 (Encryption key)
    RSA-PKCS: OK
  testing key 1 (Authentication key)
    RSA-PKCS: OK
No errors
```